### PR TITLE
add e2e test for deprecation status in subscription

### DIFF
--- a/test/e2e/testdata/subscription/example-operator.v0.2.0.yaml
+++ b/test/e2e/testdata/subscription/example-operator.v0.2.0.yaml
@@ -24,3 +24,22 @@ properties:
     value:
       packageName: packageA
       version: 1.0.1
+---
+schema: olm.deprecations
+package: packageA
+entries:
+  - reference:
+      schema: olm.package
+      name: packageA
+    message: |
+      packageA has been deprecated. Please switch to packageB.
+  - reference:
+      schema: olm.channel
+      name: stable
+    message: |
+      channel "stable" has been deprecated. Please switch to a different one.
+  - reference:
+      schema: olm.bundle
+      name: example-operator.v0.2.0
+    message: |
+      bundle "example-operator.v0.2.0" has been deprecated. Please switch to a different one.


### PR DESCRIPTION
**Description of the change:**
- Updates the subscription testdata to have deprecations for the package, channel, and v0.2.0 bundle used for the e2e tests
- Adds a new test case that expects the `OperatorDeprecated` status on the subscription to be "True".

>[!NOTE]
>This PR simply adds the e2e test. This e2e test is failing as the functionality has not yet been implemented. I've created this based on what the current iteration of the status condition is, but it should be relatively straightforward to update this as we make changes.

**Motivation for the change:**

**Architectural changes:**

<!--
If necessary, briefly describe any architectural changes, other options considered, and/or link to any EPs or design docs
-->

**Testing remarks:**

<!--
Call out any information around how you've tested the code change that may be useful for reviewers. For instance:
 * any edge-cases you have (dis)covered
 * how you have reproduced and tested for regressions in bug fixes
 * how you've tested for flakes in e2e tests or flake fixes
-->

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage
- [ ] Sufficient end-to-end test coverage
- [ ] Bug fixes are accompanied by regression test(s)
- [ ] e2e tests and flake fixes are accompanied evidence of flake testing, e.g. executing the test 100(0) times
- [ ] tech debt/todo is accompanied by issue link(s) in comments in the surrounding code
- [ ] Tests are comprehensible, e.g. Ginkgo DSL is being used appropriately
- [ ] Docs updated or added to `/doc`
- [ ] Commit messages sensible and descriptive
- [ ] Tests marked as `[FLAKE]` are truly flaky and have an issue
- [ ] Code is properly formatted


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
